### PR TITLE
docs: Add express-developer-aikit to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Contributions are welcome!
 ## Tools 🛠️
 - [Adobe Express Add-on Analytics](https://github.com/mscherotter/express-analytics) - An open-source package to add to an Adobe Express add-on to collect user analytics, a Microsoft Azure function to serve as an endpoint for the package, and a Microsoft Power BI dashboard to visualize the telemetry 🏅
 - [AI Agent skill for Add-on development](https://github.com/Sandgrouse/adobe-express-dev-skill) - An Agent Skill for AI coding assistants that provides expert knowledge and tooling for developing Adobe Express add-ons. Works with Cursor, GitHub Copilot, Windsurf, Claude Code, Continue.dev, Google Antigravity, and any MCP-compatible IDE. 🏅
+- [Express Developer AI kit](https://github.com/Irelander/express-developer-aikit) - A CLI and skill kit that complements Adobe Express's official MCP for AI-assisted add-on development. Ships progressively-loaded skills for ideation, implementation, and pre-submission review, plus commands to scan trending add-ons and bootstrap the official MCP across Cursor, Claude Code, VS Code, Codex, and Antigravity. 🏅
 - [Community MCP server](https://github.com/EnventDigital/community-express-dev-mcp) - An open source MCP server for AI coding assistants that provides Adobe Express and Sprectrum UI documentation, and code samples. 🏅
 
 ## Open Source

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Contributions are welcome!
 - [The UXP to Adobe Express Migration Journey with Zuri Klaschka](https://www.youtube.com/live/ehqmiutaJ0c) 🏅
 
 ## Tools 🛠️
+- [Express Developer AI kit](https://github.com/Irelander/express-developer-aikit) - A CLI and skill kit that complements Adobe Express's official MCP for AI-assisted add-on development. Ships progressively-loaded skills for ideation, implementation, and pre-submission review, plus commands to scan trending add-ons and bootstrap the official MCP across Cursor, Claude Code, VS Code, Codex, and Antigravity. 🏅
 - [Adobe Express Add-on Analytics](https://github.com/mscherotter/express-analytics) - An open-source package to add to an Adobe Express add-on to collect user analytics, a Microsoft Azure function to serve as an endpoint for the package, and a Microsoft Power BI dashboard to visualize the telemetry 🏅
 - [AI Agent skill for Add-on development](https://github.com/Sandgrouse/adobe-express-dev-skill) - An Agent Skill for AI coding assistants that provides expert knowledge and tooling for developing Adobe Express add-ons. Works with Cursor, GitHub Copilot, Windsurf, Claude Code, Continue.dev, Google Antigravity, and any MCP-compatible IDE. 🏅
-- [Express Developer AI kit](https://github.com/Irelander/express-developer-aikit) - A CLI and skill kit that complements Adobe Express's official MCP for AI-assisted add-on development. Ships progressively-loaded skills for ideation, implementation, and pre-submission review, plus commands to scan trending add-ons and bootstrap the official MCP across Cursor, Claude Code, VS Code, Codex, and Antigravity. 🏅
 - [Community MCP server](https://github.com/EnventDigital/community-express-dev-mcp) - An open source MCP server for AI coding assistants that provides Adobe Express and Sprectrum UI documentation, and code samples. 🏅
 
 ## Open Source


### PR DESCRIPTION
## Summary

Adds [express-developer-aikit](https://github.com/Irelander/express-developer-aikit) to the **Tools 🛠️** section.

## Notes / Details (optional)

It's a CLI and skill kit that complements Adobe Express's official MCP for AI-assisted add-on development. 
It ships progressively-loaded skills covering ideation, implementation, and pre-submission review, plus commands to scan trending add-ons and bootstrap the official MCP across Cursor, Claude Code, VS Code, Codex, and Antigravity. It sits naturally alongside the existing AI-assisted dev tooling in this section.

Requested in the Developer Champions Slack.

## Checklist
- [x] Entry added to correct section in _newest-first_ order
- [x] Link works as expected
- [x] Includes summary of resource

Choose one:
- [x] Entry links to external resource
- [ ] Entry is stored in repo and includes dedicated README
