### PR TITLE
Add Express Add‑on Test Kit & adobe‑addon‑i18n to **Tools** section (newest‑first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Contributions are welcome!
 - [The UXP to Adobe Express Migration Journey with Zuri Klaschka](https://www.youtube.com/live/ehqmiutaJ0c) 🏅
 
 ## Tools 🛠️
+- [Express Add-on Test Kit](https://github.com/Keshav-poha/express-addon-test-kit) - A production-quality monorepo designed for testing Express add-ons in dual-runtime environments (Iframe UI and Document Sandbox) directly in Node.js/jsdom environments (e.g., using Vitest or Jest).
+- [adobe-addon-i18n](https://github.com/Keshav-poha/adobe-addon-i18n) - A zero-dependency, React-first localization infrastructure built exclusively for the Adobe Express ecosystem.
 - [Express Developer AI kit](https://github.com/Irelander/express-developer-aikit) - A CLI and skill kit that complements Adobe Express's official MCP for AI-assisted add-on development. Ships progressively-loaded skills for ideation, implementation, and pre-submission review, plus commands to scan trending add-ons and bootstrap the official MCP across Cursor, Claude Code, VS Code, Codex, and Antigravity. 🏅
 - [Adobe Express Add-on Analytics](https://github.com/mscherotter/express-analytics) - An open-source package to add to an Adobe Express add-on to collect user analytics, a Microsoft Azure function to serve as an endpoint for the package, and a Microsoft Power BI dashboard to visualize the telemetry 🏅
 - [AI Agent skill for Add-on development](https://github.com/Sandgrouse/adobe-express-dev-skill) - An Agent Skill for AI coding assistants that provides expert knowledge and tooling for developing Adobe Express add-ons. Works with Cursor, GitHub Copilot, Windsurf, Claude Code, Continue.dev, Google Antigravity, and any MCP-compatible IDE. 🏅


### PR DESCRIPTION
## Summary
Adds two new resources—**Express Add‑on Test Kit** and **adobe‑addon‑i18n**—to the **Tools 🛠️** section of the repository’s `README.md`. The entries are placed at the top of the list to keep the section in newest‑first order.

## Notes / Details (optional)
- **Express Add‑on Test Kit** provides a production‑quality monorepo for testing Express add‑ons in dual‑runtime environments (Iframe UI & Document Sandbox) using Node.js/jsdom, Vitest, or Jest.  
- **adobe‑addon‑i18n** is a zero‑dependency, React‑first localization infrastructure created specifically for the Adobe Express ecosystem.  

These resources give add‑on developers ready‑to‑use tooling for testing and internationalization, reducing setup time and improving code quality.

## Checklist
- ✅ Entry added to correct section in _newest‑first_ order  
- ✅ Link works as expected  
- ✅ Includes summary of resource  

**Choose one:**
- ✅ Entry links to external resource  
- ☐ Entry is stored in repo and includes dedicated README
